### PR TITLE
docs: post-merge tidy up for OpenCode Go support (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED [x.x.x] - xxxx-xx-xx
 
+## [0.1.4] - 2026-03-29
+
+### Added
+
+- **OpenCode Go support** — Extension now fetches and serves models from the [OpenCode Go](https://opencode.ai/go) subscription tier alongside OpenCode Zen.
+- OpenCode Go models are listed with a "(Go)" suffix in the model picker for easy identification.
+- Go model IDs are suffixed with `-go` internally to avoid collisions with Zen models sharing the same name (e.g. `kimi-k2.5` vs `kimi-k2.5-go`).
+- Requests to Go models automatically route to the `https://opencode.ai/zen/go/v1` API endpoint.
+- Single API key (`OPENCODE_API_KEY`) works for both Zen and Go catalogs.
+
 ## [0.1.3] - 2026-01-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 > **Disclaimer:** This project is a community project and is not maintained by the OpenCode team (https://opencode.ai/) and has no ties to the OpenCode team.
 
 
-This extension provides **OpenCode Zen** models to VS Code via the **Language Model Chat Provider** API (vendor id: `opencode`).
+This extension provides **OpenCode Zen** and **[OpenCode Go](https://opencode.ai/go)** models to VS Code via the **Language Model Chat Provider** API (vendor id: `opencode`).
 
 ## Prerequisites
 
 - VS Code `^1.104`
 - Node.js (recent LTS recommended)
-- An OpenCode API key (`OPENCODE_API_KEY`)
+- An OpenCode API key (`OPENCODE_API_KEY`) — works for both Zen and Go catalogs
 
 ## Install
 
@@ -48,7 +48,7 @@ Open the command palette (`Ctrl/Cmd+Shift+P`):
   - Stores the key in **SecretStorage** (not in settings).
 - `OpenCode Zen: Clear API Key` (`opencodeZen.clearApiKey`)
 - `OpenCode Zen: Refresh Model List` (`opencodeZen.refreshModels`)
-  - Refetches models from `https://models.dev/api.json` (filtered to provider `opencode`).
+  - Refetches models from `https://models.dev/api.json` (filtered to providers `opencode` and `opencode-go`).
 - `OpenCode Zen: Self Test` (`opencodeZen.selfTest`)
   - Prompts for a model, then runs a small tool-calling roundtrip.
   - Output is written to the **OpenCode Zen** Output Channel.
@@ -58,3 +58,7 @@ Open the command palette (`Ctrl/Cmd+Shift+P`):
 - Tool calling is supported by streaming `LanguageModelToolCallPart` from the provider.
 - Tool execution is handled by the caller (VS Code) by sending back `LanguageModelToolResultPart` on the next request.
 - If no API key is configured, requests use `apiKey: public` and only free OpenCode Zen models are shown (matching opencode behavior).
+
+## OpenCode Go
+
+Models from [OpenCode Go](https://opencode.ai/go) appear with a **(Go)** suffix in the VS Code model picker (e.g. `Kimi K2.5 (Go)`). Requests to Go models are automatically routed to the Go API endpoint (`https://opencode.ai/zen/go/v1`). The same API key covers both Zen and Go.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "opencode-zen-chat-provider",
   "publisher": "wienans",
-  "displayName": "OpenCode Zen Provider",
-  "description": "Provides OpenCode Zen models to VS Code's Language Model API.",
+  "displayName": "OpenCode Zen & Go Provider",
+  "description": "Provides OpenCode Zen and OpenCode Go models to VS Code's Language Model API.",
   "version": "0.1.4",
   "repository": {
     "type": "git",
@@ -24,7 +24,8 @@
     "coding",
     "assistant",
     "chat provider",
-    "opencode"
+    "opencode",
+    "opencode-go"
   ],
   "icon": "assets/icon.png",
   "main": "./out/extension.js",


### PR DESCRIPTION
## Summary

This is a follow-up to PR #5, which added OpenCode Go support but didn't update the changelog, README, or marketplace metadata.

- **Changelog date** set to the actual merge date (2026-03-29)
- **README** updated to mention OpenCode Go alongside Zen
- **package.json** `displayName`, `description`, and `keywords` updated for marketplace discoverability