### PR TITLE
feat: support DeepSeek reasoning/thinking content across requests

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -8,6 +8,52 @@ import { getOutputChannel } from './output';
 
 export const VENDOR_ID = 'opencode';
 
+const REASONING_CONTENT_MIME = 'application/vnd.opencode-zen.reasoning-content';
+
+// VS Code may not preserve custom LanguageModelDataPart objects on assistant
+// messages that contain only a tool call. DeepSeek emits reasoning before the
+// tool call, so keep a local fallback keyed by the tool call id and restore it
+// when VS Code sends the next request with that tool call in the conversation.
+const reasoningContentByToolCallId = new Map<string, string>();
+
+function rememberReasoningContentForToolCall(toolCallId: string, reasoningContent: string): void {
+	const trimmed = reasoningContent.trim();
+	if (!toolCallId || trimmed.length === 0) {
+		return;
+	}
+
+	reasoningContentByToolCallId.set(toolCallId, reasoningContent);
+}
+
+function readReasoningContentForToolCall(toolCallId: string): string | undefined {
+	const value = reasoningContentByToolCallId.get(toolCallId);
+	if (value && value.trim().length > 0) {
+		return value;
+	}
+
+	return undefined;
+}
+
+
+function createReasoningContentPart(text: string): vscode.LanguageModelDataPart {
+	return new vscode.LanguageModelDataPart(
+		new TextEncoder().encode(text),
+		REASONING_CONTENT_MIME
+	);
+}
+
+function readReasoningContentPart(part: vscode.LanguageModelDataPart): string | undefined {
+	if (part.mimeType !== REASONING_CONTENT_MIME) {
+		return undefined;
+	}
+
+	try {
+		return new TextDecoder().decode(part.data);
+	} catch {
+		return undefined;
+	}
+}
+
 export class OpenCodeZenChatProvider implements vscode.LanguageModelChatProvider {
 	private readonly registry: ModelRegistry;
 	private readonly onDidChangeEmitter = new vscode.EventEmitter<void>();
@@ -107,6 +153,8 @@ export class OpenCodeZenChatProvider implements vscode.LanguageModelChatProvider
 			logDebugRequest(model, requestModelId, requestToolMode, options, coreMessages, tools, providerInfo, providerOptions);
 		}
 
+		const reasoningDeltas: string[] = [];
+
 		try {
 			await streamZen(
 				{
@@ -125,16 +173,31 @@ export class OpenCodeZenChatProvider implements vscode.LanguageModelChatProvider
 					includeUsage: promptCaching.enabled,
 				},
 				{
-					onTextDelta: (delta) => {
+					onTextDelta: (delta: string) => {
 						if (delta) {
 							progress.report(new vscode.LanguageModelTextPart(delta));
 						}
 					},
-					onToolCall: ({ toolCallId, toolName, input }) => {
+					onReasoningDelta: (delta: string) => {
+						if (delta) {
+							reasoningDeltas.push(delta);
+						}
+					},
+					onToolCall: ({ toolCallId, toolName, input }: { toolCallId: string; toolName: string; input: object }) => {
+						// DeepSeek emits reasoning before a tool call. Store it by toolCallId
+						// because VS Code may not preserve custom LanguageModelDataPart
+						// objects on assistant messages that only contain tool calls.
+						rememberReasoningContentForToolCall(toolCallId, reasoningDeltas.join(''));
+
 						progress.report(new vscode.LanguageModelToolCallPart(toolCallId, toolName, input));
 					},
-				}
+				} as any
 			);
+
+			const reasoningContent = reasoningDeltas.join('');
+			if (reasoningContent.trim().length > 0) {
+				progress.report(createReasoningContentPart(reasoningContent));
+			}
 		} catch (err) {
 			if (debugFlag) {
 				logDebugError(model, requestModelId, requestToolMode, options, coreMessages, tools, providerInfo, err);
@@ -191,6 +254,7 @@ function mapVsCodeMessageToAiSdkMessages(
 	const textImageFileParts: any[] = [];
 	const toolResultParts: any[] = [];
 	const assistantParts: any[] = [];
+	let reasoningContent = '';
 
 	for (const part of message.content) {
 		if (part instanceof vscode.LanguageModelTextPart) {
@@ -205,6 +269,11 @@ function mapVsCodeMessageToAiSdkMessages(
 
 		if (part instanceof vscode.LanguageModelToolCallPart) {
 			// Assistant-only in VS Code input, but we handle defensively.
+			const storedReasoning = readReasoningContentForToolCall(part.callId);
+			if (storedReasoning) {
+				reasoningContent += storedReasoning;
+			}
+
 			assistantParts.push({
 				type: 'tool-call',
 				toolCallId: part.callId,
@@ -226,6 +295,14 @@ function mapVsCodeMessageToAiSdkMessages(
 		}
 
 		if (part instanceof vscode.LanguageModelDataPart) {
+			const storedReasoning = readReasoningContentPart(part);
+			if (storedReasoning !== undefined) {
+				if (!isUser) {
+					reasoningContent += storedReasoning;
+				}
+				continue;
+			}
+
 			const converted = dataPartToAiSdkPart(part);
 			if (!converted) {
 				continue;
@@ -252,7 +329,16 @@ function mapVsCodeMessageToAiSdkMessages(
 			out.push({ role: 'tool', content: toolResultParts });
 		}
 	} else {
-		out.push({ role: 'assistant', content: simplifyTextOnlyContent(assistantParts) });
+		const assistantMessage: any = {
+			role: 'assistant',
+			content: simplifyTextOnlyContent(assistantParts),
+		};
+
+		if (reasoningContent.trim().length > 0) {
+			assistantMessage.reasoning_content = reasoningContent;
+		}
+
+		out.push(assistantMessage);
 	}
 
 	return out;
@@ -271,7 +357,7 @@ function simplifyTextOnlyContent(parts: any[]): any {
 
 function dataPartToAiSdkPart(part: vscode.LanguageModelDataPart): any | undefined {
 	// VS Code may include internal metadata such as cache_control in Agent/Plan mode.
-	if (part.mimeType === 'cache_control') {
+	if (part.mimeType === 'cache_control' || part.mimeType === REASONING_CONTENT_MIME) {
 		return undefined;
 	}
 

--- a/src/zenClient.ts
+++ b/src/zenClient.ts
@@ -10,8 +10,9 @@ export const ZEN_BASE_URL = 'https://opencode.ai/zen/v1';
 export type ToolMode = 'auto' | 'required';
 
 export type StreamCallbacks = {
-	onTextDelta: (delta: string) => void;
-	onToolCall: (args: { toolCallId: string; toolName: string; input: object }) => void;
+  onTextDelta: (delta: string) => void;
+  onReasoningDelta?: (delta: string) => void;
+  onToolCall: (args: { toolCallId: string; toolName: string; input: object }) => void;
 };
 
 type ApiErrorDetails = {
@@ -132,7 +133,8 @@ export async function streamZen(
 		options.apiKey,
 		baseURL,
 		options.debugLogging,
-		options.includeUsage
+		options.includeUsage,
+		options.messages
 	);
 	const endpointPath = getEndpointPath(providerNpm);
 
@@ -183,7 +185,12 @@ export async function streamZen(
 			if (part.type === 'reasoning-delta') {
 				if (part.text && part.text.length > 0) {
 					emitted = true;
-					callbacks.onTextDelta(part.text);
+
+					// Store this so we can replay it as reasoning_content on the next request.
+					callbacks.onReasoningDelta?.(part.text);
+
+					// Optional: do not show hidden thinking as normal chat text.
+					// callbacks.onTextDelta(part.text);
 				}
 				continue;
 			}
@@ -225,7 +232,8 @@ function createProvider(
 	apiKey: string,
 	baseURL: string,
 	debugLogging?: boolean,
-	includeUsage?: boolean
+	includeUsage?: boolean,
+	sourceMessages?: ModelMessage[]
 ): (modelId: string) => any {
 	switch (providerNpm) {
 		case '@ai-sdk/anthropic':
@@ -254,9 +262,92 @@ function createProvider(
 				baseURL,
 				fetch: debugLogging ? createDebugFetch() : undefined,
 				includeUsage,
-				transformRequestBody: (args) => applyOpenAICompatibleCaching(args),
+				transformRequestBody: (args) =>
+					injectOpenAICompatibleReasoningContent(
+						applyOpenAICompatibleCaching(args),
+						sourceMessages
+					),
 			});
 	}
+}
+
+
+function injectOpenAICompatibleReasoningContent(
+	args: Record<string, any>,
+	sourceMessages?: ModelMessage[]
+): Record<string, any> {
+	if (!sourceMessages || sourceMessages.length === 0 || !Array.isArray(args.messages)) {
+		return args;
+	}
+
+	const sourceAssistantMessages = sourceMessages.filter((message) => message?.role === 'assistant');
+	if (sourceAssistantMessages.length === 0) {
+		return args;
+	}
+
+	let sourceAssistantIndex = 0;
+	let changed = false;
+
+	const messages = args.messages.map((requestMessage: unknown) => {
+		if (!requestMessage || typeof requestMessage !== 'object') {
+			return requestMessage;
+		}
+
+		const record = requestMessage as Record<string, any>;
+		if (record.role !== 'assistant') {
+			return requestMessage;
+		}
+
+		const sourceMessage = sourceAssistantMessages[sourceAssistantIndex++];
+		const reasoningContent = getReasoningContentFromSourceMessage(sourceMessage);
+		if (!reasoningContent) {
+			return requestMessage;
+		}
+
+		// DeepSeek V4 thinking mode requires this exact field to be replayed on
+		// later requests. The AI SDK's OpenAI-compatible adapter may drop custom
+		// fields from ModelMessage, so we re-inject it at the final HTTP body stage.
+		if (record.reasoning_content === reasoningContent) {
+			return requestMessage;
+		}
+
+		changed = true;
+		return {
+			...record,
+			reasoning_content: reasoningContent,
+		};
+	});
+
+	return changed ? { ...args, messages } : args;
+}
+
+function getReasoningContentFromSourceMessage(message: unknown): string | undefined {
+	if (!message || typeof message !== 'object') {
+		return undefined;
+	}
+
+	const record = message as Record<string, any>;
+	const direct = record.reasoning_content ?? record.reasoningContent;
+	if (typeof direct === 'string' && direct.trim().length > 0) {
+		return direct;
+	}
+
+	// Defensive fallbacks for future/provider-specific shapes.
+	const providerOptions = record.providerOptions ?? record.provider_options;
+	const candidates = [
+		providerOptions?.[OPENAI_COMPAT_PROVIDER_NAME]?.reasoning_content,
+		providerOptions?.openaiCompatible?.reasoning_content,
+		providerOptions?.opencode?.reasoning_content,
+		providerOptions?.['opencode-zen']?.reasoning_content,
+	];
+
+	for (const candidate of candidates) {
+		if (typeof candidate === 'string' && candidate.trim().length > 0) {
+			return candidate;
+		}
+	}
+
+	return undefined;
 }
 
 function applyOpenAICompatibleCaching(args: Record<string, any>): Record<string, any> {


### PR DESCRIPTION
Capture reasoning deltas emitted by DeepSeek models (and similar providers) during streaming and preserve them across the full request/response lifecycle so that multi-turn conversations and tool-call sequences maintain thinking context.

provider.ts
- Add custom MIME type (application/vnd.opencode-zen.reasoning-content) to encode reasoning content as LanguageModelDataPart
- Introduce a Map-based fallback keyed by toolCallId because VS Code may not preserve custom DataPart objects on assistant messages that contain only tool calls
- Collect reasoning deltas into a buffer during streaming and report them as a single DataPart after the stream completes
- Re-inject stored reasoning content when mapping VS Code assistant messages back to AI SDK messages for subsequent requests

zenClient.ts
- Add optional onReasoningDelta callback to StreamCallbacks
- Route reasoning-delta parts through the new callback instead of treating them as regular text output
- Thread source messages into createProvider so reasoning_content can be re-injected at the HTTP body stage
- Add injectOpenAICompatibleReasoningContent() to restore the reasoning_content field on assistant messages (the AI SDK OpenAI-compatible adapter may strip custom fields)
- Add getReasoningContentFromSourceMessage() with defensive fallbacks for various provider-specific message shapes