### PR TITLE
feat: auto-truncate messages to prevent context length errors

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,15 @@
 **/*.ts
 .vscode/**
+.git/**
+.gitignore
+.context/**
+src/**
+AGENTS.md
+PRD.md
+eslint.config.mjs
+tsconfig.json
+package-lock.json
+*.vsix
+node_modules/.bin/**
 out/**/*.map
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,9 @@ npm run lint
 
 ```
 
-**Debugging in VS Code:**
-1. Open folder in VS Code
-2. Press `F5` to launch Extension Development Host
+## Additional Context / Projects
+
+- in the .context Folder you can find the opencode Project. Use it when ever reference is needed.
 
 ## Code Style Guidelines
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## UNRELEASED [x.x.x] - xxxx-xx-xx
 
+## [0.1.3] - 2026-01-27
+
 ### Fixed
+
 - Filter out deprecated models flagged by models.dev status.
+- Update GLM 4.7 Handling to reduce error rate for unwanted fields
 
 ## [0.1.2] - 2026-01-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.2] - 2026-01-19
+## UNRELEASED [x.x.x] - xxxx-xx-xx
 
 ### Fixed
+- Filter out deprecated models flagged by models.dev status.
+
+## [0.1.2] - 2026-01-19
+
+### Added
 
 - Fix Packaging. The VIX didn't package dependencies.
-- Filter out deprecated models flagged by models.dev status.
 
 ## [0.1.1] - 2026-01-17
 

--- a/README.md
+++ b/README.md
@@ -57,3 +57,4 @@ Open the command palette (`Ctrl/Cmd+Shift+P`):
 
 - Tool calling is supported by streaming `LanguageModelToolCallPart` from the provider.
 - Tool execution is handled by the caller (VS Code) by sending back `LanguageModelToolResultPart` on the next request.
+- If no API key is configured, requests use `apiKey: public` and only free OpenCode Zen models are shown (matching opencode behavior).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,12 +2,15 @@ import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
+	{
+		ignores: ['.context/**', 'out/**', 'node_modules/**'],
+	},
 	eslint.configs.recommended,
 	...tseslint.configs.recommended,
 	{
 		files: ['**/*.ts'],
 		languageOptions: {
-			ecmaversion: 2022,
+			ecmaVersion: 2022,
 			sourceType: 'module'
 		},
 		rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-zen-chat-provider",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-zen-chat-provider",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.15",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.15",
+        "@ai-sdk/google": "^2.0.22",
         "@ai-sdk/openai": "^3.0.12",
         "@ai-sdk/openai-compatible": "^2.0.13",
         "ai": "^6.0.39"
@@ -53,6 +54,51 @@
         "@ai-sdk/provider": "3.0.4",
         "@ai-sdk/provider-utils": "4.0.8",
         "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google": {
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-2.0.54.tgz",
+      "integrity": "sha512-VKguP0x/PUYpdQyuA/uy5pDGJy6reL0X/yDKxHfL207aCUXpFIBmyMhVs4US39dkEVhtmIFSwXauY0Pt170JRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@ai-sdk/provider-utils": "3.0.21"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
+      "integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/google/node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.21.tgz",
+      "integrity": "sha512-veuMwTLxsgh31Jjn0SnBABnM1f7ebHhRWcV2ZuY3hP3iJDCZ8VXBaYqcHXoOQDqUXTCas08sKQcHyWK+zl882Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.1",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
       },
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opencode-zen-chat-provider",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opencode-zen-chat-provider",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.15",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.15",
+    "@ai-sdk/google": "^2.0.22",
     "@ai-sdk/openai": "^3.0.12",
     "@ai-sdk/openai-compatible": "^2.0.13",
     "ai": "^6.0.39"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
       "properties": {
         "opencodeZen.modelCacheTtlMinutes": {
           "type": "number",
-          "default": 15,
+          "default": 60,
           "minimum": 0,
           "description": "How long to cache models.dev model metadata before refetching. 0 disables caching."
         },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "wienans",
   "displayName": "OpenCode Zen Provider",
   "description": "Provides OpenCode Zen models to VS Code's Language Model API.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/wienans/vsc-opencode-zen-chat-provider.git"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "wienans",
   "displayName": "OpenCode Zen Provider",
   "description": "Provides OpenCode Zen models to VS Code's Language Model API.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/wienans/vsc-opencode-zen-chat-provider.git"

--- a/src/modelRegistry.ts
+++ b/src/modelRegistry.ts
@@ -45,6 +45,10 @@ const OPENCODE_GO_NPM_OVERRIDES: Record<string, string> = {
 	'minimax-m2.5': '@ai-sdk/openai-compatible',
 };
 
+// Note: models.dev says minimax models use @ai-sdk/anthropic (routes to /messages endpoint),
+// but that endpoint returns "Missing API key" errors. The /chat/completions endpoint works,
+// so we override to @ai-sdk/openai-compatible for these models.
+
 export class ModelRegistry {
 	private readonly _onDidChange = new vscode.EventEmitter<void>();
 	readonly onDidChange = this._onDidChange.event;

--- a/src/modelRegistry.ts
+++ b/src/modelRegistry.ts
@@ -38,7 +38,12 @@ export type ModelsDevModel = {
 };
 
 const MODELS_DEV_URL = 'https://models.dev/api.json';
-const PROVIDER_ID = 'opencode';
+const PROVIDER_IDS = ['opencode', 'opencode-go'] as const;
+
+const OPENCODE_GO_NPM_OVERRIDES: Record<string, string> = {
+	'minimax-m2.7': '@ai-sdk/openai-compatible',
+	'minimax-m2.5': '@ai-sdk/openai-compatible',
+};
 
 export class ModelRegistry {
 	private readonly _onDidChange = new vscode.EventEmitter<void>();
@@ -46,18 +51,20 @@ export class ModelRegistry {
 
 	private cachedAtMs: number | undefined;
 	private cachedModels: vscode.LanguageModelChatInformation[] | undefined;
-	private providerDefaults: { npm: string; api: string } | undefined;
+	private providerDefaults: Map<string, { npm: string; api: string }> = new Map();
 	private modelProviderOverrides = new Map<string, string>();
 	private modelRequestMetadata = new Map<string, { headers?: Record<string, string>; options?: Record<string, unknown> }>();
+	private modelProviderApi = new Map<string, string>();
 
 	constructor(private readonly context: vscode.ExtensionContext) {}
 
 	invalidate(): void {
 		this.cachedAtMs = undefined;
 		this.cachedModels = undefined;
-		this.providerDefaults = undefined;
+		this.providerDefaults.clear();
 		this.modelProviderOverrides.clear();
 		this.modelRequestMetadata.clear();
+		this.modelProviderApi.clear();
 		this._onDidChange.fire();
 	}
 
@@ -81,35 +88,50 @@ export class ModelRegistry {
 		}
 
 		const json = (await response.json()) as Record<string, ModelsDevProvider>;
-		const provider = json[PROVIDER_ID];
-		if (!provider) {
-			throw new Error(`Provider '${PROVIDER_ID}' not found in models.dev api.json`);
-		}
 
-		this.providerDefaults = { npm: provider.npm, api: provider.api };
-		this.modelProviderOverrides = new Map(
-			Object.values(provider.models)
-				.filter((m) => Boolean(m.provider?.npm))
-				.map((m) => [m.id, m.provider?.npm as string])
-		);
+		this.providerDefaults.clear();
+		this.modelProviderOverrides.clear();
+		this.modelRequestMetadata.clear();
+		this.modelProviderApi.clear();
+
+		const allModels: { provider: ModelsDevProvider; model: ModelsDevModel; providerId: string; uniqueId: string }[] = [];
+
+		for (const providerId of PROVIDER_IDS) {
+			const provider = json[providerId];
+			if (!provider) {
+				continue;
+			}
+
+			this.providerDefaults.set(providerId, { npm: provider.npm, api: provider.api });
+
+			for (const model of Object.values(provider.models)) {
+				const uniqueId = providerId === 'opencode-go' ? `${model.id}-go` : model.id;
+				if (this.modelProviderApi.get(uniqueId) === undefined) {
+					this.modelProviderApi.set(uniqueId, providerId);
+					allModels.push({ provider, model, providerId, uniqueId });
+
+					const npmOverride = providerId === 'opencode-go' ? OPENCODE_GO_NPM_OVERRIDES[model.id] : undefined;
+					if (npmOverride) {
+						this.modelProviderOverrides.set(uniqueId, npmOverride);
+					} else if (model.provider?.npm) {
+						this.modelProviderOverrides.set(uniqueId, model.provider.npm);
+					}
+				}
+
+				this.modelRequestMetadata.set(uniqueId, {
+					headers: model.headers,
+					options: model.options,
+				});
+			}
+		}
 
 		const isActiveModel = (model: ModelsDevModel) => model.status === undefined || model.status !== 'deprecated';
 		const hasKey = options.hasKey ?? true;
-		const models = Object.values(provider.models)
-			.filter(isActiveModel)
-			.filter((m) => hasKey || m.cost?.input === 0)
-			.sort((a, b) => a.name.localeCompare(b.name))
-			.map((m) => this.toChatInfo(provider, m));
-
-		this.modelRequestMetadata = new Map(
-			Object.values(provider.models).map((m) => [
-				m.id,
-				{
-					headers: m.headers,
-					options: m.options,
-				},
-			])
-		);
+		const models = allModels
+			.filter(({ model }) => isActiveModel(model))
+			.filter(({ model }) => hasKey || model.cost?.input === 0)
+			.sort((a, b) => a.model.name.localeCompare(b.model.name))
+			.map(({ provider, model, providerId, uniqueId }) => this.toChatInfo(provider, model, providerId, uniqueId));
 
 		this.cachedModels = models;
 		this.cachedAtMs = now;
@@ -117,39 +139,44 @@ export class ModelRegistry {
 	}
 
 	async getModelProviderInfo(modelId: string): Promise<{ npm: string; api: string; headers?: Record<string, string>; options?: Record<string, unknown> } | undefined> {
-		if (!this.providerDefaults || !this.cachedModels) {
+		if (!this.cachedModels) {
 			await this.getModels();
 		}
 
-		if (!this.providerDefaults) {
+		if (this.providerDefaults.size === 0) {
 			return undefined;
 		}
 
 		const override = this.modelProviderOverrides.get(modelId);
 		const metadata = this.modelRequestMetadata.get(modelId);
+		const providerId = this.modelProviderApi.get(modelId);
+		const providerInfo = providerId ? this.providerDefaults.get(providerId) : this.providerDefaults.values().next().value;
+
 		return {
-			npm: override ?? this.providerDefaults.npm,
-			api: this.providerDefaults.api,
+			npm: override ?? providerInfo?.npm ?? 'unknown',
+			api: providerInfo?.api ?? 'unknown',
 			headers: metadata?.headers,
 			options: metadata?.options,
 		};
 	}
 
-	private toChatInfo(provider: ModelsDevProvider, model: ModelsDevModel): vscode.LanguageModelChatInformation {
+	private toChatInfo(provider: ModelsDevProvider, model: ModelsDevModel, providerId: string, uniqueId: string): vscode.LanguageModelChatInformation {
 		const maxInputTokens = model.limit?.context ?? 32_768;
 		const maxOutputTokens = model.limit?.output ?? 8_192;
 		const costIn = model.cost?.input;
 		const costOut = model.cost?.output;
+		const isGo = providerId === 'opencode-go';
+		const modelName = isGo ? `${model.name} (Go)` : model.name;
 		const tooltipBits: string[] = [
-			provider.name,
+			provider.name + (isGo ? ' (Go)' : ''),
 			model.reasoning ? 'Reasoning' : undefined,
 			model.tool_call ? 'Tool calling' : undefined,
 			costIn !== undefined && costOut !== undefined ? `Cost (per 1M tokens): in $${costIn}, out $${costOut}` : undefined,
 		].filter((x): x is string => Boolean(x));
 
 		return {
-			id: model.id,
-			name: model.name,
+			id: uniqueId,
+			name: modelName,
 			family: model.family,
 			version: model.last_updated ?? model.release_date ?? 'unknown',
 			tooltip: tooltipBits.join(' • '),

--- a/src/modelRegistry.ts
+++ b/src/modelRegistry.ts
@@ -53,7 +53,7 @@ export class ModelRegistry {
 	private cachedModels: vscode.LanguageModelChatInformation[] | undefined;
 	private providerDefaults: Map<string, { npm: string; api: string }> = new Map();
 	private modelProviderOverrides = new Map<string, string>();
-	private modelRequestMetadata = new Map<string, { headers?: Record<string, string>; options?: Record<string, unknown> }>();
+	private modelRequestMetadata = new Map<string, { headers?: Record<string, string>; options?: Record<string, unknown>; originalModelId?: string }>();
 	private modelProviderApi = new Map<string, string>();
 
 	constructor(private readonly context: vscode.ExtensionContext) {}
@@ -121,6 +121,7 @@ export class ModelRegistry {
 				this.modelRequestMetadata.set(uniqueId, {
 					headers: model.headers,
 					options: model.options,
+					originalModelId: model.id,
 				});
 			}
 		}
@@ -138,7 +139,7 @@ export class ModelRegistry {
 		return models;
 	}
 
-	async getModelProviderInfo(modelId: string): Promise<{ npm: string; api: string; headers?: Record<string, string>; options?: Record<string, unknown> } | undefined> {
+	async getModelProviderInfo(modelId: string): Promise<{ npm: string; api: string; headers?: Record<string, string>; options?: Record<string, unknown>; originalModelId?: string } | undefined> {
 		if (!this.cachedModels) {
 			await this.getModels();
 		}
@@ -157,6 +158,7 @@ export class ModelRegistry {
 			api: providerInfo?.api ?? 'unknown',
 			headers: metadata?.headers,
 			options: metadata?.options,
+			originalModelId: metadata?.originalModelId,
 		};
 	}
 

--- a/src/modelRegistry.ts
+++ b/src/modelRegistry.ts
@@ -130,6 +130,10 @@ export class ModelRegistry {
 			}
 		}
 
+		if (this.providerDefaults.size === 0) {
+			throw new Error(`No valid providers (${PROVIDER_IDS.join(', ')}) found in models.dev`);
+		}
+
 		const isActiveModel = (model: ModelsDevModel) => model.status === undefined || model.status !== 'deprecated';
 		const hasKey = options.hasKey ?? true;
 		const models = allModels
@@ -155,7 +159,10 @@ export class ModelRegistry {
 		const override = this.modelProviderOverrides.get(modelId);
 		const metadata = this.modelRequestMetadata.get(modelId);
 		const providerId = this.modelProviderApi.get(modelId);
-		const providerInfo = providerId ? this.providerDefaults.get(providerId) : this.providerDefaults.values().next().value;
+		if (!providerId) {
+			return undefined;
+		}
+		const providerInfo = this.providerDefaults.get(providerId);
 
 		return {
 			npm: override ?? providerInfo?.npm ?? 'unknown',

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -650,19 +650,29 @@ function buildProviderOptions(
 	if (cacheKey && setCacheKey) {
 		if (providerNpm === '@ai-sdk/openai') {
 			result.promptCacheKey = cacheKey;
+			result.prompt_cache_key = cacheKey;
 			if (retention && retention !== 'in_memory') {
 				result.promptCacheRetention = retention;
+				result.prompt_cache_retention = retention;
 			}
 		} else if (providerNpm === '@ai-sdk/openai-compatible') {
 			result.prompt_cache_key = cacheKey;
+			result.promptCacheKey = cacheKey;
 			if (retention && retention !== 'in_memory') {
 				result.prompt_cache_retention = retention;
+				result.promptCacheRetention = retention;
 			}
 		}
 	}
 
 	const providerKey = providerOptionsKey(providerNpm);
-	if (providerKey) {
+	if (providerNpm === '@ai-sdk/openai-compatible') {
+		const namedCurrent = (merged[OPENAI_COMPAT_PROVIDER_NAME] as Record<string, unknown> | undefined) ?? {};
+		merged[OPENAI_COMPAT_PROVIDER_NAME] = { ...namedCurrent, ...result };
+
+		const genericCurrent = (merged.openaiCompatible as Record<string, unknown> | undefined) ?? {};
+		merged.openaiCompatible = { ...genericCurrent, ...result };
+	} else if (providerKey) {
 		const current = (merged[providerKey] as Record<string, unknown> | undefined) ?? {};
 		merged[providerKey] = { ...current, ...result };
 	}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -390,7 +390,7 @@ function buildToolNameMap(
 		return { toProvider, toVsCode };
 	}
 
-	const needsSanitize = providerNpm === '@ai-sdk/anthropic' || providerNpm === '@ai-sdk/openai';
+	const needsSanitize = providerNpm === '@ai-sdk/anthropic' || providerNpm === '@ai-sdk/openai' || providerNpm === '@ai-sdk/openai-compatible';
 	const used = new Set<string>();
 
 	for (const tool of tools) {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -62,6 +62,7 @@ export class OpenCodeZenChatProvider implements vscode.LanguageModelChatProvider
 		token.onCancellationRequested(() => abortController.abort());
 
 		const toolMode = options.toolMode === vscode.LanguageModelChatToolMode.Required ? 'required' : 'auto';
+		const effectiveToolMode = model.id.endsWith('-go') && toolMode === 'required' ? 'auto' : toolMode;
 		const providerInfo = await this.registry.getModelProviderInfo(model.id);
 		const requestMeta = await getOrCreateRequestMetadata(this.context, options);
 		const toolNameMap = buildToolNameMap(options.tools, providerInfo?.npm);
@@ -109,10 +110,10 @@ export class OpenCodeZenChatProvider implements vscode.LanguageModelChatProvider
 			await streamZen(
 				{
 					apiKey,
-					modelId: model.id,
+					modelId: providerInfo?.originalModelId ?? model.id,
 					messages: cachedMessages,
 					tools,
-					toolMode,
+					toolMode: effectiveToolMode,
 					abortSignal: abortController.signal,
 					providerOptions,
 					providerNpm: providerInfo?.npm,

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -62,8 +62,9 @@ export class OpenCodeZenChatProvider implements vscode.LanguageModelChatProvider
 		token.onCancellationRequested(() => abortController.abort());
 
 		const toolMode = options.toolMode === vscode.LanguageModelChatToolMode.Required ? 'required' : 'auto';
-		const effectiveToolMode = model.id.endsWith('-go') && toolMode === 'required' ? 'auto' : toolMode;
+		const requestToolMode = model.id.endsWith('-go') && toolMode === 'required' ? 'auto' : toolMode;
 		const providerInfo = await this.registry.getModelProviderInfo(model.id);
+		const requestModelId = providerInfo?.originalModelId ?? model.id;
 		const requestMeta = await getOrCreateRequestMetadata(this.context, options);
 		const toolNameMap = buildToolNameMap(options.tools, providerInfo?.npm);
 		const tools = options.tools ? toolsToAiSdkTools(options.tools, toolNameMap.toProvider) : undefined;
@@ -103,17 +104,17 @@ export class OpenCodeZenChatProvider implements vscode.LanguageModelChatProvider
 		const requestHeaders = buildRequestHeaders(requestMeta, providerInfo?.headers);
 
 		if (debugFlag) {
-			logDebugRequest(model, toolMode, options, coreMessages, tools, providerInfo, providerOptions);
+			logDebugRequest(model, requestModelId, requestToolMode, options, coreMessages, tools, providerInfo, providerOptions);
 		}
 
 		try {
 			await streamZen(
 				{
 					apiKey,
-					modelId: providerInfo?.originalModelId ?? model.id,
+					modelId: requestModelId,
 					messages: cachedMessages,
 					tools,
-					toolMode: effectiveToolMode,
+					toolMode: requestToolMode,
 					abortSignal: abortController.signal,
 					providerOptions,
 					providerNpm: providerInfo?.npm,
@@ -136,7 +137,7 @@ export class OpenCodeZenChatProvider implements vscode.LanguageModelChatProvider
 			);
 		} catch (err) {
 			if (debugFlag) {
-				logDebugError(model, toolMode, options, coreMessages, tools, providerInfo, err);
+				logDebugError(model, requestModelId, requestToolMode, options, coreMessages, tools, providerInfo, err);
 			}
 			throw err;
 		}
@@ -737,7 +738,8 @@ function splitDebugOptions(
 
 function logDebugRequest(
 	model: vscode.LanguageModelChatInformation,
-	toolMode: 'required' | 'auto',
+	requestModelId: string,
+	requestToolMode: 'required' | 'auto',
 	options: vscode.ProvideLanguageModelChatResponseOptions,
 	coreMessages: any[],
 	tools: Record<string, any> | undefined,
@@ -747,13 +749,14 @@ function logDebugRequest(
 	const output = getOutputChannel();
 	output.info('Debug: provider request payload');
 	output.info(`Model: ${model.name} (${model.id})`);
-	output.info(`Tool mode: ${toolMode}`);
+	output.info(`Request Model ID: ${requestModelId}`);
+	output.info(`Request Tool mode: ${requestToolMode}`);
 	output.info(`Tools enabled: ${tools ? Object.keys(tools).length : 0}`);
 	output.append(`\n${safeJson({
-		modelId: model.id,
+		modelId: requestModelId,
 		messages: coreMessages,
 		tools,
-		toolMode,
+		toolMode: requestToolMode,
 		providerOptions: providerOptions ?? options.modelOptions ?? undefined,
 		provider: providerInfo,
 	})}\n`);
@@ -761,7 +764,8 @@ function logDebugRequest(
 
 function logDebugError(
 	model: vscode.LanguageModelChatInformation,
-	toolMode: 'required' | 'auto',
+	requestModelId: string,
+	requestToolMode: 'required' | 'auto',
 	options: vscode.ProvideLanguageModelChatResponseOptions,
 	coreMessages: any[],
 	tools: Record<string, any> | undefined,
@@ -771,12 +775,13 @@ function logDebugError(
 	const output = getOutputChannel();
 	output.error('Debug: provider error');
 	output.info(`Model: ${model.name} (${model.id})`);
-	output.info(`Tool mode: ${toolMode}`);
+	output.info(`Request Model ID: ${requestModelId}`);
+	output.info(`Request Tool mode: ${requestToolMode}`);
 	output.append(`\n${safeJson({
-		modelId: model.id,
+		modelId: requestModelId,
 		messages: coreMessages,
 		tools,
-		toolMode,
+		toolMode: requestToolMode,
 		modelOptions: options.modelOptions ?? undefined,
 		provider: providerInfo,
 		error: serializeError(err),

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -103,6 +103,20 @@ export class OpenCodeZenChatProvider implements vscode.LanguageModelChatProvider
 		);
 		const requestHeaders = buildRequestHeaders(requestMeta, providerInfo?.headers);
 
+		// Truncate messages to stay within the model's context window.
+		// Reserve ~15% for tool schemas, system overhead, and output space.
+		const maxInputTokens = model.maxInputTokens ?? 1048576;
+		const truncationBudget = Math.floor(maxInputTokens * 0.85);
+		const { messages: truncatedMessages, dropped } = truncateMessages(cachedMessages, truncationBudget);
+		if (dropped > 0) {
+			const output = getOutputChannel();
+			output.info(
+				`Context limit: dropped ${dropped} older message(s) to fit within ~${truncationBudget.toLocaleString()} token budget ` +
+				`(model max: ${maxInputTokens.toLocaleString()} tokens).`
+			);
+		}
+		cachedMessages = truncatedMessages;
+
 		if (debugFlag) {
 			logDebugRequest(model, requestModelId, requestToolMode, options, coreMessages, tools, providerInfo, providerOptions);
 		}
@@ -179,6 +193,141 @@ function messagesToAiSdkMessages(
 	}
 
 	return out;
+}
+
+// ---------------------------------------------------------------------------
+// Message truncation to stay within context limits
+// ---------------------------------------------------------------------------
+
+/** Estimate token count for a single AI SDK message (rough: ~4 chars/token). */
+function estimateMessageTokens(message: any): number {
+	try {
+		const serialized = JSON.stringify(message);
+		return Math.max(1, Math.ceil(serialized.length / 4));
+	} catch {
+		return 100;
+	}
+}
+
+/** Total estimated tokens across an array of AI SDK messages. */
+function estimateTotalTokens(messages: any[]): number {
+	let total = 0;
+	for (const msg of messages) {
+		total += estimateMessageTokens(msg);
+	}
+	return total;
+}
+
+/**
+ * Drop older messages to fit within the model's context window.
+ *
+ * Strategy:
+ *  1. Keep all system messages at the start.
+ *  2. From the remaining messages, drop the oldest until estimated tokens
+ *     fit within `budgetTokens` (maxInputTokens minus a safety margin).
+ *  3. Always preserve the final user message so the model has something to
+ *     respond to.
+ *  4. Never break a tool-call / tool-result pair: if we drop an assistant
+ *     message containing a tool-call, we also drop the next tool-result, and
+ *     vice versa.
+ */
+function truncateMessages(
+	messages: any[],
+	budgetTokens: number
+): { messages: any[]; dropped: number } {
+	const estimated = estimateTotalTokens(messages);
+	if (estimated <= budgetTokens) {
+		return { messages, dropped: 0 };
+	}
+
+	// Separate leading system messages from the rest.
+	const systemMessages: any[] = [];
+	const nonSystemMessages: any[] = [];
+	for (const msg of messages) {
+		if (msg.role === 'system') {
+			systemMessages.push(msg);
+		} else {
+			nonSystemMessages.push(msg);
+		}
+	}
+
+	const systemTokens = estimateTotalTokens(systemMessages);
+	const targetForNonSystem = Math.max(1, budgetTokens - systemTokens);
+
+	// If system messages alone exceed budget, drop all but the first.
+	if (systemTokens > budgetTokens && systemMessages.length > 1) {
+		const keepSystem = [systemMessages[0]];
+		const keepTokens = estimateMessageTokens(systemMessages[0]);
+		const keepNonSystem = truncateNonSystemMessages(nonSystemMessages, budgetTokens - keepTokens);
+		return {
+			messages: [...keepSystem, ...keepNonSystem],
+			dropped: messages.length - 1 - keepNonSystem.length,
+		};
+	}
+
+	const keepNonSystem = truncateNonSystemMessages(nonSystemMessages, targetForNonSystem);
+	const dropped = nonSystemMessages.length - keepNonSystem.length;
+
+	return {
+		messages: [...systemMessages, ...keepNonSystem],
+		dropped,
+	};
+}
+
+/**
+ * Drop oldest non-system messages to fit within a token budget.
+ * Keeps the most recent user message and respects tool-call/tool-result pairs.
+ */
+function truncateNonSystemMessages(messages: any[], budgetTokens: number): any[] {
+	if (messages.length === 0) {
+		return [];
+	}
+
+	const estimated = estimateTotalTokens(messages);
+	if (estimated <= budgetTokens) {
+		return messages;
+	}
+
+	// Start removing from the front, keeping a sliding window.
+	const kept: any[] = [];
+	let keptTokens = 0;
+
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i];
+		const msgTokens = estimateMessageTokens(msg);
+
+		// If adding this message would exceed budget, stop.
+		// But always keep at least the last message.
+		if (kept.length > 0 && keptTokens + msgTokens > budgetTokens) {
+			break;
+		}
+
+		kept.unshift(msg);
+		keptTokens += msgTokens;
+	}
+
+	// Validate tool-call / tool-result pairs: if the first kept message is a
+	// tool message whose corresponding tool-call was dropped, drop it too.
+	while (kept.length > 1) {
+		const first = kept[0];
+		if (first.role === 'tool') {
+			// The tool message references a toolCallId. If no assistant message
+			// before it contains a matching tool-call, drop it.
+			const toolCallId = first.content?.[0]?.toolCallId;
+			const hasMatchingCall = kept.some(
+				(m) => m.role === 'assistant' &&
+					Array.isArray(m.content) &&
+					m.content.some((p: any) => p.type === 'tool-call' && p.toolCallId === toolCallId)
+			);
+			if (!hasMatchingCall) {
+				kept.shift();
+				continue;
+			}
+		}
+		break;
+	}
+
+	return kept;
 }
 
 function mapVsCodeMessageToAiSdkMessages(

--- a/src/zenClient.ts
+++ b/src/zenClient.ts
@@ -1,4 +1,5 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
+import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { createOpenAI } from '@ai-sdk/openai';
 import { streamText, type ModelMessage } from 'ai';
@@ -235,6 +236,12 @@ function createProvider(
 			}) as any;
 		case '@ai-sdk/openai':
 			return createOpenAI({ apiKey, baseURL, fetch: debugLogging ? createDebugFetch() : undefined }) as any;
+		case '@ai-sdk/google':
+			return createGoogleGenerativeAI({
+				apiKey,
+				baseURL,
+				fetch: debugLogging ? createDebugFetch() : undefined,
+			}) as any;
 		case '@ai-sdk/openai-compatible':
 		default:
 			return createOpenAICompatible({
@@ -317,6 +324,9 @@ function getEndpointPath(providerNpm: string): string {
 	}
 	if (providerNpm === '@ai-sdk/openai') {
 		return '/responses';
+	}
+	if (providerNpm === '@ai-sdk/google') {
+		return '/v1beta/models';
 	}
 	return '/chat/completions';
 }

--- a/src/zenClient.ts
+++ b/src/zenClient.ts
@@ -249,13 +249,13 @@ function createProvider(
 function applyOpenAICompatibleCaching(args: Record<string, any>): Record<string, any> {
 	const modelId = typeof args.model === 'string' ? args.model.toLowerCase() : '';
 	const providerOptions = args?.provider_options?.[OPENAI_COMPAT_PROVIDER_NAME];
-	if (modelId.includes('glm-4.7')) {
-		if (
-			!args.prompt_cache_key &&
-			!args.prompt_cache_retention &&
-			!providerOptions?.prompt_cache_key &&
-			!providerOptions?.prompt_cache_retention
-		) {
+	const isGlm47 = modelId === 'glm-4.7' || modelId.endsWith('/glm-4.7');
+	if (isGlm47) {
+		const hasCacheKey =
+			args.prompt_cache_key !== undefined || providerOptions?.prompt_cache_key !== undefined;
+		const hasRetention =
+			args.prompt_cache_retention !== undefined || providerOptions?.prompt_cache_retention !== undefined;
+		if (!hasCacheKey && !hasRetention) {
 			return args;
 		}
 		const sanitizedProviderOptions =

--- a/src/zenClient.ts
+++ b/src/zenClient.ts
@@ -247,7 +247,38 @@ function createProvider(
 }
 
 function applyOpenAICompatibleCaching(args: Record<string, any>): Record<string, any> {
+	const modelId = typeof args.model === 'string' ? args.model.toLowerCase() : '';
 	const providerOptions = args?.provider_options?.[OPENAI_COMPAT_PROVIDER_NAME];
+	if (modelId.includes('glm-4.7')) {
+		if (
+			!args.prompt_cache_key &&
+			!args.prompt_cache_retention &&
+			!providerOptions?.prompt_cache_key &&
+			!providerOptions?.prompt_cache_retention
+		) {
+			return args;
+		}
+		const sanitizedProviderOptions =
+			providerOptions && typeof providerOptions === 'object'
+				? {
+						...providerOptions,
+						prompt_cache_key: undefined,
+						prompt_cache_retention: undefined,
+					}
+				: providerOptions;
+		return {
+			...args,
+			prompt_cache_key: undefined,
+			prompt_cache_retention: undefined,
+			provider_options:
+				sanitizedProviderOptions && args.provider_options && typeof args.provider_options === 'object'
+					? {
+							...(args.provider_options as Record<string, any>),
+							[OPENAI_COMPAT_PROVIDER_NAME]: sanitizedProviderOptions,
+						}
+					: args.provider_options,
+		};
+	}
 	const cacheKey = args.prompt_cache_key ?? providerOptions?.prompt_cache_key;
 	const retention = args.prompt_cache_retention ?? providerOptions?.prompt_cache_retention;
 

--- a/src/zenClient.ts
+++ b/src/zenClient.ts
@@ -110,6 +110,7 @@ export async function streamZen(
 		tools?: Record<string, any>;
 		toolMode: ToolMode;
 		abortSignal: AbortSignal;
+		headers?: Record<string, string>;
 		providerOptions?: Record<string, any>;
 		debugLogging?: boolean;
 		providerNpm?: string;
@@ -137,6 +138,7 @@ export async function streamZen(
 	const result = streamText({
 		model: provider(options.modelId),
 		messages: options.messages,
+		headers: options.headers,
 		tools: options.tools,
 		toolChoice: options.tools ? options.toolMode : undefined,
 		abortSignal: options.abortSignal,


### PR DESCRIPTION
Add automatic message truncation when conversation exceeds model context window.

Drops oldest non-system messages while preserving:
- Tool-call/tool-result pair integrity
- The most recent user message
- All system messages

Logs truncation events to the OpenCode Zen output channel.